### PR TITLE
feat: Support axios@^1

### DIFF
--- a/__tests__/adapter.test.ts
+++ b/__tests__/adapter.test.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+import { axiosTauriApiAdapter } from '../src';
+
+test('should create axios instance with this adapter', () => {
+  // should compile
+  const instance = axios.create({ adapter: axiosTauriApiAdapter })
+
+  expect(instance).toBeTruthy();
+})

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,21 +1,21 @@
-import { buillRequestUrl } from './../src/util'
+import { buildRequestUrl } from './../src/util'
 
 test('only baseURL', () => {
-  expect(buillRequestUrl({ baseURL: 'https://www.persiliao.com' })).toBe('https://www.persiliao.com')
+  expect(buildRequestUrl({ baseURL: 'https://www.persiliao.com' })).toBe('https://www.persiliao.com')
 })
 
 test('only url', () => {
-  expect(buillRequestUrl({ url: 'https://www.persiliao.com' })).toBe('https://www.persiliao.com')
+  expect(buildRequestUrl({ url: 'https://www.persiliao.com' })).toBe('https://www.persiliao.com')
 })
 
 test('only url with params', () => {
-  expect(buillRequestUrl({ url: 'https://www.persiliao.com?foo=bar' })).toBe('https://www.persiliao.com?foo=bar')
+  expect(buildRequestUrl({ url: 'https://www.persiliao.com?foo=bar' })).toBe('https://www.persiliao.com?foo=bar')
 })
 
 test('only url with params & config.params', () => {
-  expect(buillRequestUrl({ url: 'https://www.persiliao.com?foo=bar', params: { 'name': 'PersiLiao'} })).toBe('https://www.persiliao.com?foo=bar&name=PersiLiao')
+  expect(buildRequestUrl({ url: 'https://www.persiliao.com?foo=bar', params: { 'name': 'PersiLiao'} })).toBe('https://www.persiliao.com?foo=bar&name=PersiLiao')
 })
 
 test('only url & params', () => {
-  expect(buillRequestUrl({ url: 'https://www.persiliao.com', params: { 'foo': 'bar' } })).toBe('https://www.persiliao.com?foo=bar')
+  expect(buildRequestUrl({ url: 'https://www.persiliao.com', params: { 'foo': 'bar' } })).toBe('https://www.persiliao.com?foo=bar')
 })

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^1.0.2",
-    "axios": "^0.27.2",
+    "axios": "^1.3.3",
     "build-url-ts": "^6.1.3",
     "http-status-codes": "^2.2.0",
     "url-parse": "^1.5.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ specifiers:
   '@types/jest': ^28.1.6
   '@types/node': ^18.0.5
   '@types/url-parse': ^1.4.8
-  axios: ^0.27.2
+  axios: ^1.3.3
   build-url-ts: ^6.1.3
   conventional-changelog-cli: ^2.2.2
   http-status-codes: ^2.2.0
@@ -22,7 +22,7 @@ specifiers:
 
 dependencies:
   '@tauri-apps/api': 1.0.2
-  axios: 0.27.2
+  axios: 1.3.3
   build-url-ts: 6.1.3
   http-status-codes: 2.2.0
   url-parse: 1.5.10
@@ -886,11 +886,12 @@ packages:
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  /axios/0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+  /axios/1.3.3:
+    resolution: {integrity: sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==}
     dependencies:
       follow-redirects: 1.15.1
       form-data: 4.0.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -1318,8 +1319,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -3104,6 +3105,10 @@ packages:
       kleur: 3.0.3
       sisteransi: 1.0.5
     dev: true
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /psl/1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   buildBasicAuthorization,
   buildJWTAuthorization,
   buildTauriRequestData,
-  buillRequestUrl,
+  buildRequestUrl,
   getTauriResponseType,
 } from './util'
 
@@ -30,7 +30,7 @@ export const axiosTauriApiAdapter = (config: TauriAxiosRequestConfig): AxiosProm
         },
         responseType: getTauriResponseType(config.responseType),
         timeout: timeout,
-        url: buillRequestUrl(config),
+        url: buildRequestUrl(config),
         method: <HttpVerb>config.method?.toUpperCase(),
       })
       .then((response) => {

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,9 +1,9 @@
-import { AxiosRequestConfig } from 'axios'
+import { InternalAxiosRequestConfig } from 'axios'
 
 export interface Authorization {
   Authorization: string
 }
 
-export interface TauriAxiosRequestConfig extends AxiosRequestConfig {
+export interface TauriAxiosRequestConfig extends InternalAxiosRequestConfig {
   jwt?: string
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -56,7 +56,7 @@ export function buildTauriRequestData(data?: any): Body | undefined {
   return Body.bytes(data)
 }
 
-export const buillRequestUrl = (config: TauriAxiosRequestConfig): string => {
+export const buildRequestUrl = (config: Omit<TauriAxiosRequestConfig, 'headers'>): string => {
   if (
     (config.baseURL === undefined || config.baseURL === null || config.baseURL.trim() === '') &&
     (config.url === undefined || config.url === null || config.url.trim() === '')


### PR DESCRIPTION
BREAKING CHANGE: `axiosTauriApiAdapter` now accepts a config that extends `InternalAxiosRequestConfig`