### PR TITLE
fix: Handle multiple set-cookie headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,10 @@ export const axiosTauriApiAdapter = (config: TauriAxiosRequestConfig): AxiosProm
             data: response.data,
             status: response.status,
             statusText: statusText,
-            headers: response.headers,
+            headers: {
+              ...response.headers,
+              'set-cookie': response.rawHeaders['set-cookie'],
+            },
             config: config,
           })
         } else {


### PR DESCRIPTION
Handling of headers with multiple `set-cookie` keys:

> The easiest fix is just to substitute the value from Response.rawHeaders for set-cookie, like this:
```javascript
const headers = {
	...response.headers,
	'set-cookie': response.rawHeaders['set-cookie'],
}
```


Fixes: https://github.com/persiliao/axios-tauri-api-adapter/issues/8
