### PR TITLE
fix: Request data builder

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,4 +1,5 @@
-import { buildRequestUrl } from './../src/util'
+import { buildRequestUrl, buildTauriRequestData } from './../src/util';
+import { TauriBodyType } from '../src/constants';
 
 test('only baseURL', () => {
   expect(buildRequestUrl({ baseURL: 'https://www.persiliao.com' })).toBe('https://www.persiliao.com')
@@ -18,4 +19,61 @@ test('only url with params & config.params', () => {
 
 test('only url & params', () => {
   expect(buildRequestUrl({ url: 'https://www.persiliao.com', params: { 'foo': 'bar' } })).toBe('https://www.persiliao.com?foo=bar')
+})
+
+
+test('data payload with correct type', () => {
+
+  // Tuples containing the value and its expected Tauri body type.
+  const payloads: [unknown, TauriBodyType | undefined][] = [
+    [
+      "banana!", 
+      TauriBodyType.TEXT
+    ],
+    [
+      { id: 1, name: "Banana", }, 
+      TauriBodyType.JSON
+    ],
+    [
+      new FormData, 
+      TauriBodyType.FORM
+    ],
+    [
+      new Uint32Array, 
+      TauriBodyType.BYTES
+    ],
+    [
+      new Float32Array, 
+      TauriBodyType.BYTES
+    ],
+    [
+      new BigInt64Array, 
+      TauriBodyType.BYTES
+    ],
+    [
+      [1, 2, 3], 
+      TauriBodyType.JSON
+    ],
+    [
+      ["THE WORLD"], 
+      TauriBodyType.JSON
+    ],
+    [
+      null, 
+      undefined
+    ],
+    [
+      undefined, 
+      undefined
+    ],
+    [
+      Symbol("foo"),
+      undefined,
+    ]
+  ];
+
+  for (const [value, expectedBodyType] of payloads) {
+    const body = buildTauriRequestData(value);
+    expect(body?.type).toBe(expectedBodyType);
+  }
 })

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "jest --config jestconfig.json"
   },
   "dependencies": {
-    "@tauri-apps/api": "^1.0.2",
+    "@tauri-apps/api": "^1.5.3",
     "axios": "^1.3.3",
     "build-url-ts": "^6.1.3",
     "http-status-codes": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@tauri-apps/api':
-    specifier: ^1.0.2
-    version: 1.0.2
+    specifier: ^1.5.3
+    version: 1.5.3
   axios:
     specifier: ^1.3.3
     version: 1.6.0
@@ -758,9 +758,9 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: true
 
-  /@tauri-apps/api@1.0.2:
-    resolution: {integrity: sha512-yuNW0oeJ1/ZA7wNF1KgxhHrSu5viPVzY/UgUczzN5ptLM8dH15Juy5rEGkoHfeXGju90Y/l22hi3BtIrp/za+w==}
-    engines: {node: '>= 12.22.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
+  /@tauri-apps/api@1.5.3:
+    resolution: {integrity: sha512-zxnDjHHKjOsrIzZm6nO5Xapb/BxqUq1tc7cGkFXsFkGTsSWgCPH1D8mm0XS9weJY2OaR73I3k3S+b7eSzJDfqA==}
+    engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
     dev: false
 
   /@tootallnate/once@2.0.0:
@@ -1760,8 +1760,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -1898,7 +1898,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.16.2
+      uglify-js: 3.17.4
     dev: true
 
   /hard-rejection@2.1.0:
@@ -2406,7 +2406,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-leak-detector@28.1.3:
@@ -3789,8 +3789,8 @@ packages:
     hasBin: true
     dev: true
 
-  /uglify-js@3.16.2:
-    resolution: {integrity: sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==}
+  /uglify-js@3.17.4:
+    resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+export const TEXT_SERIALIZABLE_TYPES = new Set(["string", "boolean", "number", "bigint"]);
+
+export enum TauriBodyType {
+    TEXT = "Text",
+    JSON = "Json",
+    FORM = "Form",
+    BYTES = "Bytes",
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,8 @@
-export const TEXT_SERIALIZABLE_TYPES = new Set(["string", "boolean", "number", "bigint"]);
+export const TEXT_SERIALIZABLE_TYPES = new Set(['string', 'boolean', 'number', 'bigint'])
 
 export enum TauriBodyType {
-    TEXT = "Text",
-    JSON = "Json",
-    FORM = "Form",
-    BYTES = "Bytes",
+  TEXT = 'Text',
+  JSON = 'Json',
+  FORM = 'Form',
+  BYTES = 'Bytes',
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,27 +44,24 @@ export function getTauriResponseType(type?: AxiosResponseType): TauriResponseTyp
 }
 
 export function buildTauriRequestData(data?: any): Body | undefined {
-  
-  if (data === undefined || data === null)
-    return undefined;
-
-  else if (TEXT_SERIALIZABLE_TYPES.has(typeof data))
-    return Body.text(`${data}`); // string casting just in case
-
-  else if (data instanceof FormData)
-    // @ts-ignore  
-    return Body.form(data);
-
+  if (data === undefined || data === null) {
+    return undefined
+  } else if (TEXT_SERIALIZABLE_TYPES.has(typeof data)) {
+    return Body.text(`${data}`) // string casting just in case
+  } else if (data instanceof FormData) {
+    // @ts-ignore
+    return Body.form(data)
+  }
   // Checking if is `TypedArray` as it describes an array-like view
   // of an underlying binary data buffer.
   // @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
-  else if (isTypedArray(data))
-    return Body.bytes(data);
+  else if (isTypedArray(data)) {
+    return Body.bytes(data)
+  } else if (typeof data === 'object') {
+    return Body.json(data)
+  }
 
-  else if (typeof data === "object")
-    return Body.json(data);
-
-  return undefined;
+  return undefined
 }
 
 export const buildRequestUrl = (config: Omit<TauriAxiosRequestConfig, 'headers'>): string => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,7 +4,6 @@ import buildUrl, { IQueryParams } from 'build-url-ts'
 import URLParse from 'url-parse'
 import { Authorization, TauriAxiosRequestConfig } from './type'
 import { TEXT_SERIALIZABLE_TYPES } from './constants'
-import { isTypedArray } from 'util/types'
 
 export const base64Decode = (str: string): string => Buffer.from(str, 'base64').toString('binary')
 export const base64Encode = (str: string): string => Buffer.from(str, 'binary').toString('base64')
@@ -55,8 +54,8 @@ export function buildTauriRequestData(data?: any): Body | undefined {
   // Checking if is `TypedArray` as it describes an array-like view
   // of an underlying binary data buffer.
   // @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
-  else if (isTypedArray(data)) {
-    return Body.bytes(data)
+  else if (ArrayBuffer.isView(data)) {
+    return Body.bytes(data.buffer)
   } else if (typeof data === 'object') {
     return Body.json(data)
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,13 +45,13 @@ export function buildTauriRequestData(data?: any): Body | undefined {
   if (data === undefined || data === null) {
     return undefined
   }
-  if (typeof data === 'string') {
+  if (data instanceof FormData) {
+    // @ts-ignore
+    return Body.form(data)
+  } else if (typeof data === 'string') {
     return Body.text(data)
   } else if (typeof data === 'object') {
     return Body.json(data)
-  } else if (data instanceof FormData) {
-    // @ts-ignore
-    return Body.form(data)
   }
   return Body.bytes(data)
 }


### PR DESCRIPTION
This PR fixes a faulty behaviour in `buildTauriRequestData`. It led to a bug where the output body type was not the one expected. This could be observed when trying to pass a `FormData` to the utility: even though the body type should have been `Body.form`, it gave `Body.json`. A similar case could happen when passing bytes buffers such as `UInt32Array`. The issue occurred due to a condition checking if the data type was a json before checking any other types (as it only checks if `typeof data` is `object` and `FormData` instances and array-like types always give `object`).